### PR TITLE
Comment unused laser_model arguments

### DIFF
--- a/ari_2dnav/launch/move_base.launch
+++ b/ari_2dnav/launch/move_base.launch
@@ -13,7 +13,7 @@
     <arg name="global_planner" value="$(arg global_planner)"/>
     <arg name="local_planner"  value="$(arg local_planner)"/>
     <arg name="public_sim"     value="$(arg public_sim)"/>
-    <arg name="laser_model" value="$(arg laser_model)"/>
+    <!-- <arg name="laser_model" value="$(arg laser_model)"/> -->
   </include>
 
 </launch>

--- a/ari_2dnav/launch/state_machine.launch
+++ b/ari_2dnav/launch/state_machine.launch
@@ -4,10 +4,10 @@
   <arg name="state"  default="localization"/>
   <arg name="public_sim"     default="false"/>
   <arg name="laser_model"   default="false"/>
-  
+
   <include file="$(find pal_navigation_cfg_ari)/launch/state_machine.launch">
     <arg name="state"  value="$(arg state)"/>
-    <arg name="laser_model"  value="$(arg laser_model)"/>
+    <!-- <arg name="laser_model"  value="$(arg laser_model)"/> -->
     <arg name="public_sim"     value="$(arg public_sim)"/>
   </include>
 


### PR DESCRIPTION
This PR removes some unused `laser_model` arguments to suppress launching errors in simulation.

If you execute this command, the simulation should open without any launch error:

```
roslaunch ari_2dnav_gazebo ari_mapping.launch public_sim:=true
```
